### PR TITLE
Refactor/starter questions prompts

### DIFF
--- a/code/app.py
+++ b/code/app.py
@@ -62,7 +62,7 @@ async def set_starters(user=None):
             ),
         cl.Starter(
             label="Standorte",
-            message="Liste alle Standorte der UB Mannheim mit ihrer fachlichen Ausrichtung und der Webseite auf."
+            message="Gib mir eine Übersicht über alle Standorte der UB Mannheim mit ihrer fachlichen Ausrichtung und dem Link zur entsprechenden Webseite."
             ),
         cl.Starter(
             label="Neuigkeiten",

--- a/code/prompts.py
+++ b/code/prompts.py
@@ -1,0 +1,43 @@
+# === Chat Prompts ===
+BASE_SYSTEM_PROMPT = """Du bist der virtuelle Assistent der Universitätsbibliothek Mannheim.
+Freundlich, kompetent und unterstützend beantwortest du Fragen zur Nutzung der Bibliothek,
+zu Services, Recherchemöglichkeiten und mehr.
+**Regeln:**
+1. Beantworte Fragen ausschließlich auf Basis der bereitgestellten Dokumente oder Kontexts. Nutze kein allgemeines Vorwissen.
+2. Antworten max. 500 Zeichen lang.
+3. Keine Annahmen, Erfindungen oder Fantasie-URLs.
+4. Keine Buchempfehlungen – verweise stattdessen auf die Primo-Suche: https://primo.bib.uni-mannheim.de
+5. Keine Paperempfehlungen - verweise stattdessen auf die MADOC-Suche: https://madoc.bib.uni-mannheim.de
+6. Keine Datenempfehlungen - verweise stattdessen auf die MADATA-Suche: https://madata.bib.uni-mannheim.de
+7. Heute ist {today}. Nutze das für aktuelle Fragen (z. B. Öffnungszeiten). Verweise auf: https://www.bib.uni-mannheim.de/oeffnungszeiten
+8. Antworte immer in der Sprache: {{language}}."""
+
+# === Prompts for Data Processing ===
+PROMPT_POST_PROCESSING = """You are an expert for preparing markdown documents for Retrieval-Augmented Generation (RAG). 
+Perform the following tasks on the provided documents that are sourced from the website of the Universitätsbibliothek Mannheim:
+1. Clean the structure, improve headings, embed links using markdown syntax. Do not add content to the markdown page itself. Simply refine it.
+2. Add a YAML header (without markdown wrapping!) by using this template:
+---
+title: title of document
+source_url: URL of document
+category: one of these categories: [Benutzung, Öffnungszeiten, Standorte, Services, Medien, Projekte]
+tags: [a list of precise, descriptive keywords]
+language: de, en or other language tags
+---
+3. Chunk content into semantic blocks of 100–300 words. Remove redundancy and make the file suitable for semantic search or chatbot use.
+4. Return the processed markdown file.
+
+<Example Output>
+---
+title: Deutscher Reichsanzeiger und Preußischer Staatsanzeiger
+source_url: https://www.bib.uni-mannheim.de/lehren-und-forschen/forschungsdatenzentrum/datenangebot-des-fdz/deutscher-reichsanzeiger-und-preussischer-staatsanzeiger/
+category:
+tags: [Forschungsdatenzentrum, Datenangebot des FDZ, Deutscher Reichsanziger und Preussischer Staatsanzeiger, Zeitungen]
+language: de
+---
+
+# First Heading of Markdown Page
+The content of the markdown page...
+
+<Document to process>
+"""

--- a/code/prompts.py
+++ b/code/prompts.py
@@ -3,14 +3,24 @@ BASE_SYSTEM_PROMPT = """Du bist der virtuelle Assistent der Universitätsbibliot
 Freundlich, kompetent und unterstützend beantwortest du Fragen zur Nutzung der Bibliothek,
 zu Services, Recherchemöglichkeiten und mehr.
 **Regeln:**
-1. Beantworte Fragen ausschließlich auf Basis der bereitgestellten Dokumente oder Kontexts. Nutze kein allgemeines Vorwissen.
+1. Beantworte Fragen ausschließlich auf Basis der bereitgestellten Dokumente oder Kontexts. Nutze kein allgemeines Vorwissen. Wenn du etwas nicht weißt, sage "Dazu habe ich leider keine Informationen."
 2. Antworten max. 500 Zeichen lang.
 3. Keine Annahmen, Erfindungen oder Fantasie-URLs.
 4. Keine Buchempfehlungen – verweise stattdessen auf die Primo-Suche: https://primo.bib.uni-mannheim.de
 5. Keine Paperempfehlungen - verweise stattdessen auf die MADOC-Suche: https://madoc.bib.uni-mannheim.de
 6. Keine Datenempfehlungen - verweise stattdessen auf die MADATA-Suche: https://madata.bib.uni-mannheim.de
-7. Heute ist {today}. Nutze das für aktuelle Fragen (z. B. Öffnungszeiten). Verweise auf: https://www.bib.uni-mannheim.de/oeffnungszeiten
-8. Antworte immer in der Sprache: {{language}}."""
+7. Interpretiere gängige Abkürzungen im Kontext der Bibliothek und verstehe sie als Synonyme:
+   - UB = Universitätsbibliothek
+   - BIB = Bibliothek
+   - DBD = Digitale Bibliotheksdienste
+   - FDZ = Forschungsdatenzentrum
+   - VHT = Abteilung Verwaltung, Haushalt und Technik
+   - HWS = Herbst-/Wintersemester
+   - FSS = Frühjahrs-/Sommersemester
+   - MA = Mannheim
+8. Heute ist {today}. Nutze das für aktuelle Fragen (z. B. Öffnungszeiten). Verweise auf: https://www.bib.uni-mannheim.de/oeffnungszeiten
+9. Beende deine Antwort **immer** mit einem nützlichen Link zu einer Webseite der UB Mannheim, der zum Kontext der Frage passt.
+10. Antworte immer in der Sprache: {{language}}."""
 
 # === Prompts for Data Processing ===
 PROMPT_POST_PROCESSING = """You are an expert for preparing markdown documents for Retrieval-Augmented Generation (RAG). 

--- a/code/rag_local.py
+++ b/code/rag_local.py
@@ -1,4 +1,7 @@
+import os
+import datetime
 import chromadb.config
+from rich import print
 from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -7,17 +10,13 @@ from langchain import hub
 from langchain_community.document_loaders import UnstructuredMarkdownLoader
 from config import DATA_DIR, PERSIST_DIR, CHUNK_SIZE, CHUNK_OVERLAP
 from operator import itemgetter
-import datetime
-import os
-from conversation_memory import create_conversation_context
-from language_detection import detect_language_and_get_name
+from prompts import BASE_SYSTEM_PROMPT
 
 
 def format_docs(docs):
     return "\n\n".join(doc.page_content for doc in docs)
 
-
-async def create_rag_chain():
+async def create_rag_chain(debug=False):
     embedding_model = OpenAIEmbeddings(
         model="text-embedding-ada-002",
         openai_api_key=os.getenv("OPENAI_API_KEY")
@@ -52,20 +51,7 @@ async def create_rag_chain():
     retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 4})
     prompt = hub.pull("rlm/rag-prompt")
     today = datetime.datetime.now().strftime('%B %d, %Y %H:%M:%S')
-
-    prompt.messages[0].prompt.template = f"""Du bist der virtuelle Assistent der Universitätsbibliothek Mannheim.
-Freundlich, kompetent und unterstützend beantwortest du Fragen zur Nutzung der Bibliothek,
-zu Services, Recherchemöglichkeiten und mehr.
-**Regeln:**
-1. Beantworte Fragen ausschließlich auf Basis der bereitgestellten Dokumente oder Kontexts. Nutze kein allgemeines Vorwissen.
-2. Antworten max. 500 Zeichen lang.
-3. Keine Annahmen, Erfindungen oder Fantasie-URLs.
-4. Keine Buchempfehlungen – verweise stattdessen auf die Primo-Suche: https://primo.bib.uni-mannheim.de
-5. Keine Paperempfehlungen - verweise stattdessen auf die MADOC-Suche: https://madoc.bib.uni-mannheim.de
-6. Keine Datenempfehlungen - verweise stattdessen auf die MADATA-Suche: https://madata.bib.uni-mannheim.de
-7. Antworte immer in der Sprache: {{language}}.
-8. Heute ist {today}. Nutze das für aktuelle Fragen (z. B. Öffnungszeiten). Verweise auf: https://www.bib.uni-mannheim.de/oeffnungszeiten
-
+    prompt.messages[0].prompt.template = f"""{BASE_SYSTEM_PROMPT.format(today=today)}
 **Konversationsverlauf:**
 {{conversation_context}}
 
@@ -75,6 +61,11 @@ Antwort:"""
 
     llm = ChatOpenAI(model_name="gpt-4o-mini-2024-07-18", temperature=0, streaming=True, openai_api_key=os.getenv("OPENAI_API_KEY"))
 
+    def log_prompt(prompt):
+        if debug:
+            print(f"\n[bold yellow]Prompt sent to LLM:[/bold yellow]\n{prompt}\n")
+        return prompt
+
     return (
         {
             "context": itemgetter("question") | retriever | format_docs,
@@ -83,6 +74,7 @@ Antwort:"""
             "language": itemgetter("language")
         }
         | prompt
+        | log_prompt  # Log the prompt before sending to LLM
         | llm
         | StrOutputParser()
     )

--- a/code/utils.py
+++ b/code/utils.py
@@ -17,7 +17,10 @@ def backup_dir_with_timestamp(dir_path):
     path = Path(dir_path)
     if path.exists() and path.is_dir():
         timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-        backup_path = path.parent / f"{path.name}_backup_{timestamp}"
+        backup_dir = path.parent / "backups"
+        if not backup_dir.exists():
+            backup_dir.mkdir(exist_ok=True, parents=True)
+        backup_path = backup_dir / f"{path.name}_backup_{timestamp}"
         shutil.copytree(path, backup_path)
         print(f"[bold cyan][BACKUP] {dir_path} -> {backup_path} ... Done.")
         


### PR DESCRIPTION
- moved all prompts (system prompts for chat as well as prompt for data processing) to `prompts.py`
- improved the chat system prompt by
    - adding common abbreviations (DBD, FDZ, MA) etc. 
    - a rule handling responses to question out of scope ("Dazu habe ich keine Informationen.")
- improved starter questions
- added a debugging option for invoking local rag chain (`create_rag_chain()` of `rag_local.py`) and printing the final message that is sent to the LLM (with context, history, user message and detected_language) to CLI
    - defaults to `False`
- backups of `/markdown` and `/markdown_processed` dir are now saved to a subfolder `data/backups` to remove clutter from `/data`