### PR TITLE
Fixes and markdown updates

### DIFF
--- a/code/llm_query_processing.py
+++ b/code/llm_query_processing.py
@@ -4,19 +4,9 @@ import json
 import json_repair
 from rich import print
 from openai import AsyncOpenAI
+from utils import is_valid_json
 from prompts import ROUTER_AUGMENTOR_PROMPT
 
-
-def is_valid_json(json_string):
-    """
-    Check if json_string is valid JSON.
-    """
-    try:
-        json.loads(json_string)
-        return True
-    except json.JSONDecodeError as e:
-        print(f"... Invalid JSON: {e}")
-        return False
 
 async def route_and_augment_query(
     client: AsyncOpenAI | None,

--- a/code/prompts.py
+++ b/code/prompts.py
@@ -118,14 +118,18 @@ ROUTER_AUGMENTOR_PROMPT = f"""You are an expert query processor for the Universi
 - Preserve this language throughout processing
 
 **Category Classification Rules:**
-- 'news': Users requesting SPECIFICALLY actual news from the Universitätsbibliothek (blog posts etc.) or current events from library sources and nothing else.
+- 'news': Users requesting SPECIFICALLY current/recent news from the Universitätsbibliothek (blog posts, announcements from the last few months) or current events from the library. Historical events or dates before the current year are NOT news.
+    - Additional rule: If a query contains a date more than 1 year in the past, it cannot be classified as 'news'.
 - 'sitzplatz': Questions SPECIFICALLY about seat availability, occupancy levels, or free seats.
-- 'message': All other inquiries (locations, directions, services, databases, opening hours, literature searches, etc.).
+- 'message': All other inquiries (locations, directions, services, databases, opening hours, literature searches, historical research, academic questions, etc.).
 
 **Key Distinctions:**
 - "Wo ist A3?" → 'message' (location question)
 - "Sind in A3 Plätze frei?" → 'sitzplatz' (seat availability)
-- Reading news → 'news' | Accessing news databases → 'message'
+- "I want to read some news" → 'message'
+- "I want to access news databases" → 'message'
+- "Was geschah am [historical date]?" → 'message' (historical research)
+- "Gibt es neue Nachrichten aus der Bibliothek?" → 'news' (current library news request)
 
 **Query Augmentation Rules:**
 1. Interpret abbreviations: {ABBREVIATIONS}

--- a/code/utils.py
+++ b/code/utils.py
@@ -10,6 +10,17 @@ def ensure_dir(dir) -> None:
     if not path.exists():
         path.mkdir(parents=True)
         
+def is_valid_json(json_string):
+    """
+    Check if json_string is valid JSON.
+    """
+    try:
+        json.loads(json_string)
+        return True
+    except json.JSONDecodeError as e:
+        print(f"... Invalid JSON: {e}")
+        return False
+
 def backup_dir_with_timestamp(dir_path):
     """
     If dir_path exists, copy it to dir_path_backup_YYYYmmdd.

--- a/data/markdown/open-science.md
+++ b/data/markdown/open-science.md
@@ -1,0 +1,62 @@
+
+
+# Open Science (https://www.uni-mannheim.de/open-science/)
+
+As a collective term, Open Science includes both classical aspects such as Open Access, open data and software as well as concepts with an impact on society such as Third Mission, Citizen Science or Open Innovation. The driving factors of Open Science are trans­parent and inclusive research practices, open access to scientific findings and the reproducibility of research results.
+The University of Mannheim is committed to trans­parent and replicable research and encourages these goals through research practices of open science (such as e.g. pre-registration, open data, open materials and open source). On a national level the university joined the German Reproducibility Network (https://reproducibilitynetwork.de/) (GRN) in July 2022. Since autumn 2022, the university's recruitment guidelines (see Bewerbungs­leitfaden  (https://intranet.uni-mannheim.de/arbeitsplatz/personalangelegenheiten/personalabteilung/professorinnen-und-professoren/berufung-und-ernennung/)in the intranet) have included a request for a planned contribution to Open Science as an option in the application documents for professor­ships. Moreover, it has established an Open Science Office (https://www.uni-mannheim.de/open-science/open-science-office/) supporting its researchers at all career stages and from all disciplines.
+
+
+### Open Science Office
+
+The Open Science Office fosters and supports Open Science approaches of researchers across all academic disciplines at the University of Mannheim.
+
+
+### Best Practices (https://www.uni-mannheim.de/open-science/best-practices/)
+
+Best Practices
+Have a look at some best practice Open Science examples from across the university.
+
+
+
+### Pre-registration (https://www.uni-mannheim.de/open-science/pre-registration/)
+
+Pre-registration
+Improve the trans­parency of your research and pre-register your research!
+
+
+
+### Open Science Grants (https://www.uni-mannheim.de/open-science/grants/)
+
+Open Science Grants
+The Open Science Office incentivises trans­parent and reproducible research practices through financial support with grants of up to EUR 6,500.
+
+
+
+### Open Educational Resources (OERs) (https://www.uni-mannheim.de/open-science/oer/)
+
+Open Educational Resources (OERs)
+Share your teaching material with others or reuse theirs!
+
+
+
+### Open Science Council (https://www.uni-mannheim.de/open-science-council/)
+
+Open Science Council
+The Open Science Council serves as a advisory body which suppports the Open Science Office.
+
+
+
+## Events
+
+
+
+### Open Science Seminars: Pre-registration of Research Projects
+
+
+
+### Open Science Seminars: Predatory Publishing
+
+
+
+### Open Science Seminars: Docker for Reproducible Research
+

--- a/data/markdown/open-science_open-science-office.md
+++ b/data/markdown/open-science_open-science-office.md
@@ -1,0 +1,83 @@
+
+
+# Open Science Office (https://www.uni-mannheim.de/open-science/open-science-office/)
+
+The Open Science Office supports researchers at all career stages and from all disciplines in implementing Open Science practices and is interconnected with the Open Access team, the Research Data Center (https://www.bib.uni-mannheim.de/en/teaching-and-research/research-data-center-fdz/), the Research Support Unit (https://www.uni-mannheim.de/universitaet/organisation/verwaltung/dezernat-i/) and other players.
+
+
+## Training and Educating Researchers
+
+At the Open Science Office we provide and organise Open Science seminars as part of the Research Skills Seminar (https://www.bib.uni-mannheim.de/en/teaching-and-research/research-skills/) series at UB Mannheim every semester. 
+The Open Science Office typically offers training oppurtunities on the following topics, but we are always open to your ideas as well.
+* Open Access, Open Data and Open Research Practices
+* Preregistrations and Registered Reports
+* Technical Workflows for Reproducibility (e.g., R Markdown and Docker)
+* Citicen Science
+
+
+## Research Support and Services
+
+Do you have questions about how to deal with Open Science practices in your research project or next publication? You can contact the Open Science Office for one-on-one consulations. 
+**We are happy to answer questions related to:**
+
+* Implementing individual Open Science Practices
+* What to write and plan for in terms of Open Science for your next funding proposal to the DFG, BW-Stiftung, or EU
+* Integrating Open Science Practices into your research workflow with your collaborators
+* Finding suitible research infratructures to support you with Open Science Practices
+
+
+
+## Open Science Grants
+
+The University of Mannheim is committed to the goals of trans­parent and inclusive research practices, open access to scientific results, and reproducibility of research. In the course of this, university-wide Open Science Grants are offered (https://www.uni-mannheim.de/en/open-science/grants/).
+In annual funding rounds applications for small research projects and events related to Open Science are funded. The Open Science Office organises the calls, the review process, and the distribution of funds, as well as accomanying the project during its entire duration.
+
+
+### Call for Applications (https://www.uni-mannheim.de/open-science/grants/)
+
+Call for Applications
+Find out more about applying for Open Science Grants here.
+
+
+
+### Funded Projects (https://www.uni-mannheim.de/open-science/best-practices/)
+
+Funded Projects
+You can check out our funded Open Science Projects on our Best Practices page.
+
+
+
+## Networking and Outreach
+
+The Open Science Office provides orgnisational and financial support to a grassroot initiative, the Mannheim Open Science Meetup (https://osf.io/gzf9h/), who provide a space to discuss current Open Science Topics. If you are interested in joining, sign up to the mailing list here (https://www.listserv.dfn.de/sympa/info/mannheim-open-science).
+The Open Science Office also works nationally and internationally for the University of Mannheim, which is an institutional member of the German Reproducibility Network  (https://reproducibilitynetwork.de)one of the Global Reproduciblity Networks (https://www.ukrn.org/global-networks/), to promote an institutionalized approach on Open Science.
+
+
+## Contact
+
+
+
+### Dr. David Philip Morgan
+
+Open Science Officer | Referent für Forschungs­daten­management (Sozial­wissenschaften)
+* Adresse: Universität Mannheim, Universitäts­bibliothek, Schloss Schneckenhof West – Raum SN 283, 68161 Mannheim
+* Telefon: +49 621 181-2990
+* E-Mail: david.morgan@uni-mannheim.de
+* ORCID-ID: 0000-0001-8213-451X (https://orcid.org/0000-0001-8213-451X)
+
+
+### Dr. Hendrik Platte
+
+Fach­referent für Politik­wissenschaft, Soziologie und Psychologie | Ansprech­partner EDZ
+* Adresse: Universität Mannheim, Universitäts­bibliothek, Schloss Schneckenhof West – Raum SN 283, Mannheim
+* Telefon: +49 621 181-2990
+* E-Mail: edz.ub@uni-mannheim.de
+
+
+### Dr. Philipp Zumstein
+
+Open-Access-Beauftragter der Universität Mannheim
+* Adresse: Universität Mannheim, Universitäts­bibliothek, Schneckenhof West – Raum SN 269.1, 68161 Mannheim
+* Telefon: +49 621 181-3006
+* E-Mail: philipp.zumstein@uni-mannheim.de
+* ORCID-ID: 0000-0002-6485-9434 (https://orcid.org/0000-0002-6485-9434)

--- a/data/markdown_processed/open-science.md
+++ b/data/markdown_processed/open-science.md
@@ -1,0 +1,36 @@
+---
+title: Open Science at the University of Mannheim
+source_url: https://www.uni-mannheim.de/open-science/
+category: Projekte
+tags: [Open Science, Transparente Forschung, Reproduzierbarkeit, Open Access, Open Educational Resources]
+language: de
+---
+
+# Open Science
+Open Science encompasses classical aspects such as Open Access, open data, and software, as well as societal concepts like Third Mission, Citizen Science, and Open Innovation. The driving factors are transparent and inclusive research practices, open access to scientific findings, and the reproducibility of research results.
+
+The University of Mannheim is committed to transparent and replicable research, encouraging these goals through open science practices, including pre-registration, open data, open materials, and open source. The university joined the [German Reproducibility Network (GRN)](https://reproducibilitynetwork.de/) in July 2022. Since autumn 2022, the university's recruitment guidelines have included a request for a planned contribution to Open Science in the application documents for professorships. Additionally, an [Open Science Office](https://www.uni-mannheim.de/open-science/open-science-office/) has been established to support researchers at all career stages and from all disciplines.
+
+## Open Science Office
+The Open Science Office fosters and supports Open Science approaches of researchers across all academic disciplines at the University of Mannheim.
+
+## Best Practices
+Explore some best practice Open Science examples from across the university at [Best Practices](https://www.uni-mannheim.de/open-science/best-practices/).
+
+## Pre-registration
+Enhance the transparency of your research by pre-registering your projects at [Pre-registration](https://www.uni-mannheim.de/open-science/pre-registration/).
+
+## Open Science Grants
+The Open Science Office incentivizes transparent and reproducible research practices through financial support with grants of up to EUR 6,500. More information can be found at [Open Science Grants](https://www.uni-mannheim.de/open-science/grants/).
+
+## Open Educational Resources (OERs)
+Share your teaching materials or reuse those of others at [Open Educational Resources (OERs)](https://www.uni-mannheim.de/open-science/oer/).
+
+## Open Science Council
+The [Open Science Council](https://www.uni-mannheim.de/open-science-council/) serves as an advisory body supporting the Open Science Office.
+
+## Events
+### Open Science Seminars
+- Pre-registration of Research Projects
+- Predatory Publishing
+- Docker for Reproducible Research

--- a/data/markdown_processed/open-science_open-science-office.md
+++ b/data/markdown_processed/open-science_open-science-office.md
@@ -1,0 +1,67 @@
+---
+title: Open Science Office at Universität Mannheim
+source_url: https://www.uni-mannheim.de/open-science/open-science-office/
+category: Services
+tags: [Open Science, Research Support, Training, Grants, Networking]
+language: de
+---
+
+# Open Science Office
+
+The Open Science Office supports researchers at all career stages and from all disciplines in implementing Open Science practices. It is interconnected with the [Open Access team](https://www.uni-mannheim.de/open-science/open-science-office/), the [Research Data Center](https://www.bib.uni-mannheim.de/en/teaching-and-research/research-data-center-fdz/), the [Research Support Unit](https://www.uni-mannheim.de/universitaet/organisation/verwaltung/dezernat-i/), and other players.
+
+## Training and Educating Researchers
+
+At the Open Science Office, we provide and organize Open Science seminars as part of the [Research Skills Seminar](https://www.bib.uni-mannheim.de/en/teaching-and-research/research-skills/) series at UB Mannheim every semester. The Open Science Office typically offers training opportunities on the following topics, but we are always open to your ideas:
+
+* Open Access, Open Data, and Open Research Practices
+* Preregistrations and Registered Reports
+* Technical Workflows for Reproducibility (e.g., R Markdown and Docker)
+* Citizen Science
+
+## Research Support and Services
+
+Do you have questions about how to deal with Open Science practices in your research project or next publication? You can contact the Open Science Office for one-on-one consultations. We are happy to answer questions related to:
+
+* Implementing individual Open Science Practices
+* What to write and plan for in terms of Open Science for your next funding proposal to the DFG, BW-Stiftung, or EU
+* Integrating Open Science Practices into your research workflow with your collaborators
+* Finding suitable research infrastructures to support you with Open Science Practices
+
+## Open Science Grants
+
+The University of Mannheim is committed to transparent and inclusive research practices, open access to scientific results, and reproducibility of research. In this context, university-wide [Open Science Grants](https://www.uni-mannheim.de/en/open-science/grants/) are offered. In annual funding rounds, applications for small research projects and events related to Open Science are funded. The Open Science Office organizes the calls, the review process, and the distribution of funds, as well as accompanying the project during its entire duration.
+
+### Call for Applications
+
+Find out more about applying for [Open Science Grants](https://www.uni-mannheim.de/open-science/grants/) here.
+
+### Funded Projects
+
+You can check out our funded [Open Science Projects](https://www.uni-mannheim.de/open-science/best-practices/) on our Best Practices page.
+
+## Networking and Outreach
+
+The Open Science Office provides organizational and financial support to a grassroots initiative, the [Mannheim Open Science Meetup](https://osf.io/gzf9h/), which provides a space to discuss current Open Science topics. If you are interested in joining, sign up for the [mailing list](https://www.listserv.dfn.de/sympa/info/mannheim-open-science). The Open Science Office also works nationally and internationally for the University of Mannheim, which is an institutional member of the [German Reproducibility Network](https://reproducibilitynetwork.de) and one of the [Global Reproducibility Networks](https://www.ukrn.org/global-networks/), to promote an institutionalized approach to Open Science.
+
+## Contact
+
+### Dr. David Philip Morgan
+Open Science Officer | Referent für Forschungsdatenmanagement (Sozialwissenschaften)  
+* Adresse: Universität Mannheim, Universitätsbibliothek, Schloss Schneckenhof West – Raum SN 283, 68161 Mannheim  
+* Telefon: +49 621 181-2990  
+* E-Mail: [david.morgan@uni-mannheim.de](mailto:david.morgan@uni-mannheim.de)  
+* ORCID-ID: [0000-0001-8213-451X](https://orcid.org/0000-0001-8213-451X)  
+
+### Dr. Hendrik Platte
+Fachreferent für Politikwissenschaft, Soziologie und Psychologie | Ansprechpartner EDZ  
+* Adresse: Universität Mannheim, Universitätsbibliothek, Schloss Schneckenhof West – Raum SN 283, Mannheim  
+* Telefon: +49 621 181-2990  
+* E-Mail: [edz.ub@uni-mannheim.de](mailto:edz.ub@uni-mannheim.de)  
+
+### Dr. Philipp Zumstein
+Open-Access-Beauftragter der Universität Mannheim  
+* Adresse: Universität Mannheim, Universitätsbibliothek, Schneckenhof West – Raum SN 269.1, 68161 Mannheim  
+* Telefon: +49 621 181-3006  
+* E-Mail: [philipp.zumstein@uni-mannheim.de](mailto:philipp.zumstein@uni-mannheim.de)  
+* ORCID-ID: [0000-0002-6485-9434](https://orcid.org/0000-0002-6485-9434)  

--- a/data/urls.txt
+++ b/data/urls.txt
@@ -153,3 +153,5 @@ https://www.bib.uni-mannheim.de/standorte/explab-schloss-schneckenhof/
 https://www.bib.uni-mannheim.de/standorte/infocenter/
 https://www.bib.uni-mannheim.de/standorte/learning-center-schloss-schneckenhof/
 https://www.bib.uni-mannheim.de/standorte/sicherheit-in-den-bibliotheksbereichen/
+https://www.uni-mannheim.de/open-science/
+https://www.uni-mannheim.de/open-science/open-science-office/


### PR DESCRIPTION
- fix: build `conversation_history` before adding it to the current session to avoid sending the user's query twice in one llm call
- move `is_valid_json()` from `llm_query_processing.py` to `utils.py` for more generic use across modules
- add Open Science Office docs to  `urls.txt`, `/data/markdown` and `/data/markdown_processed`