### PR TITLE
Update chainlit to v2.9.6

### DIFF
--- a/code/custom_data_layer.py
+++ b/code/custom_data_layer.py
@@ -115,6 +115,9 @@ class CustomDataLayer(BaseDataLayer):
     async def delete_step(self, step_id: str) -> None:
         self.steps.pop(step_id, None)
 
+    async def get_favorite_steps(self) -> List["StepDict"]:
+        return []
+
     async def get_thread_author(self, thread_id: str) -> str:
         return self.threads.get(thread_id, {}).get("userId", "Unknown")
 

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,6 +1,6 @@
 aiosqlite~=0.21.0
 beautifulsoup4~=4.13.5
-chainlit~=2.8.3
+chainlit~=2.9.6
 chromadb~=1.0.20
 fastapi~=0.116.2
 feedparser~=6.0.11


### PR DESCRIPTION
- update chainlit to v2.9.6 to fix security issue
- add get_favorite_steps() to CustomDataLayer() which is an expected method in chainlit v2.9.6 for the CustomDataLayer implementation