### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/code/crawler.py
+++ b/code/crawler.py
@@ -7,7 +7,7 @@ import xml.etree.ElementTree as ET
 from bs4 import BeautifulSoup, Tag
 from pathlib import Path
 from typing import Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from tqdm import tqdm
 
 import utils
@@ -183,7 +183,15 @@ def parse_uma_address_contact(element: Tag) -> list[str]:
         lines.append(f"- E-Mail: {email}")
 
     orcid_tag = element.find(
-        "a", href=lambda x: isinstance(x, str) and "orcid.org" in x
+        "a",
+        href=lambda x: (
+            isinstance(x, str)
+            and (
+                (lambda h: h == "orcid.org" or (h is not None and h.endswith(".orcid.org")))(
+                    urlparse(x).hostname
+                )
+            )
+        ),
     )
     orcid = (
         orcid_tag.get_text(strip=True)


### PR DESCRIPTION
Potential fix for [https://github.com/UB-Mannheim/UBi/security/code-scanning/2](https://github.com/UB-Mannheim/UBi/security/code-scanning/2)

In general, instead of checking whether a trusted hostname is a substring of the entire URL, you should parse the URL and verify its `hostname` component. For ORCID, we want to accept only links whose hostname is exactly `orcid.org` or a controlled subdomain such as `www.orcid.org`, not arbitrary URLs that merely contain `orcid.org` somewhere in the string.

The best targeted fix here is to replace the substring predicate `lambda x: isinstance(x, str) and "orcid.org" in x` with a predicate that (1) ensures `x` is a string, (2) parses it using `urllib.parse.urlparse`, and (3) checks that the parsed hostname equals `orcid.org` or ends with `.orcid.org`. We can reuse the existing `urllib.parse` import line by expanding it from `from urllib.parse import urljoin` to `from urllib.parse import urljoin, urlparse`. Then, in `parse_uma_address_contact`, we adjust the lambda used in `element.find` so that it matches only URLs whose host is `orcid.org` or a subdomain thereof. This preserves the original functionality (“find ORCID links”), but does so in a robust, host-aware way.

Concretely:
- Modify the import at line 10 to also import `urlparse`.
- Change the `orcid_tag = element.find("a", href=lambda ...)` call to parse `href` and check `parsed.hostname` with an `endswith` test on `.orcid.org` or equality to `orcid.org`.

No new helper methods are strictly necessary; the logic can remain inline in the lambda.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
