### PR TITLE
Add custom_docs folder + update crawling / llm processing logic

### DIFF
--- a/code/config.py
+++ b/code/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 ENV_PATH = Path("../.env")
 URLS_TO_CRAWL = Path("../data/urls.txt")
 CRAWL_DIR = Path("../data/markdown")
+CUSTOM_DOCS_DIR = Path("../data/custom_docs")
 DATA_DIR = Path("../data/markdown_processed")
 PERSIST_DIR = Path("../data/vectorstore")
 CHUNK_SIZE = 1000

--- a/code/prompts.py
+++ b/code/prompts.py
@@ -1,5 +1,6 @@
 # === Common Abbreviations ===
-ABBREVIATIONS = """- UB = Universitätsbibliothek (University Library)
+ABBREVIATIONS = """- **UBi** / **ubi** = KI-Chatbot der Universitätsbibliothek (AI Chatbot of the University Library)
+   - UB = Universitätsbibliothek (University Library)
    - BIB = Bibliothek (Library)
    - DBD = Digitale Bibliotheksdienste (Digital Library Services)
    - FDZ = Forschungsdatenzentrum (Research Data Center)
@@ -17,7 +18,8 @@ ABBREVIATIONS = """- UB = Universitätsbibliothek (University Library)
    - Ausleihzentrum = Ausleihzentrum Schloss Westflügel (Central Lending Library Schloss Westflügel)
    - Study Skills = University Library courses and workshops with useful tips on academic research and writing
    - RDM Seminars / Research Data Management Seminars = Forschungsdatenzentrum courses and workshops on research data management
-   - BERD = BERD@NFDI
+   - BERD = BERD@NFDI (NFDI consortia for business, economics and related data hosted at University of Mannheim)
+   - GIP = German Internet Panel (Infrastructure for surveys and a long-term study at the University of Mannheim)
    - Uni MA = Universität Mannheim (Mannheim University)
    - DHBW = Duale Hochschule Baden-Württemberg Mannheim (Baden-Wuerttemberg Cooperative State University (DHBW))
    - Uni HD = Universität Heidelberg (Heidelberg University)
@@ -26,7 +28,7 @@ ABBREVIATIONS = """- UB = Universitätsbibliothek (University Library)
 
 # === Chat Prompts ===
 BASE_SYSTEM_PROMPT = f"""# System Role
-You are the virtual assistant of the University Library Mannheim (UB Mannheim). Your purpose is to help users navigate library services, resources, and facilities based solely on the information provided in your knowledge base.
+You are the UBi, the virtual assistant of Mannheim University Library (UB Mannheim). Your purpose is to help users navigate library services, resources, and facilities based solely on the information provided in your knowledge base.
 
 ## Core Principles
 - **Friendly & Professional**: Maintain a helpful, welcoming tone
@@ -135,7 +137,7 @@ Assistant: "I don't have information about that in my current resources. For fur
 - Including source lists or bibliographies"""
 
 # === Router, Langauge Detection and Prompt Augmentation ===
-ROUTER_AUGMENTOR_PROMPT = f"""You are an expert query processor for the Universitätsbibliothek Mannheim's RAG chatbot system. You will analyze user queries and provide structured output that includes language detection, category routing, and query augmentation - all in a single response.
+ROUTER_AUGMENTOR_PROMPT = f"""You are an expert query processor for UBi (the chatbot of the Mannheim University Library (UB Mannheim)). You will analyze user queries and provide structured output that includes language detection, category routing, and query augmentation - all in a single response.
 
 # Your Tasks:
 1. Detect the language of the user's CURRENT query

--- a/code/prompts.py
+++ b/code/prompts.py
@@ -28,7 +28,7 @@ ABBREVIATIONS = """- **UBi** / **ubi** = KI-Chatbot der Universitätsbibliothek 
 
 # === Chat Prompts ===
 BASE_SYSTEM_PROMPT = f"""# System Role
-You are the UBi, the virtual assistant of Mannheim University Library (UB Mannheim). Your purpose is to help users navigate library services, resources, and facilities based solely on the information provided in your knowledge base.
+You are UBi, the virtual assistant of Mannheim University Library (UB Mannheim). Your purpose is to help users navigate library services, resources, and facilities based solely on the information provided in your knowledge base.
 
 ## Core Principles
 - **Friendly & Professional**: Maintain a helpful, welcoming tone

--- a/data/custom_docs/ubi-chatbot-nutzungsbedingungen.md
+++ b/data/custom_docs/ubi-chatbot-nutzungsbedingungen.md
@@ -1,0 +1,40 @@
+---
+title: Nutzungsbedingungen für den UBi (KI-Chatbot) der Universitätsbibliothek Mannheim
+source_url_de: https://chat.bib.uni-mannheim.de/public/docs/ubi_policy.pdf
+source_url_en: https://chat.bib.uni-mannheim.de/public/docs/ubi_policy.pdf
+category: Services
+tags: ['Nutzungsbedingungen UBi', 'KI-Chatbot der Universitätsbibliothek Mannheim', 'UBi', 'Serviceangebot', 'Rechtliches']
+language: de
+---
+
+# Nutzungsbedingungen für UBi, der KI-Chatbot der UB Mannheim
+
+Der KI-Chatbot der Universitätsbibliothek Mannheim unterstützt Nutzer\*innen mit Informationen zu den Services der UB.
+
+Mit der Nutzung dieses Chatbots erklären Sie sich mit folgenden Bedingungen **einverstanden**:
+
+* Die vom KI-Chatbot bereitgestellten Inhalte werden automatisiert erzeugt und dienen ausschließlich allgemeinen Informations- und Unterstützungszwe-cken rund um die UB Mannheim. Der Chatbot erteilt keine Auskünfte zu individuellen Nutzungsverhältnissen, beispielweise zum Ausleihstatus. **Es wird keine Gewähr für die Richtigkeit, Vollständigkeit oder Aktualität der Ausgaben übernommen.** Die Nutzung der Inhalte erfolgt auf eigenes Risiko.
+* Bitte prüfen Sie alle bereitgestellten Inhalte sorgfältig. Soweit möglich, werden am Ende der Antwort Links zu den genutzten Quellen angezeigt, über die Sie die Informationen nachvollziehen und überprüfen können.
+* Wenn Sie nicht volljährig sind, dürfen Sie den Chatbot nur mit Einwilligung Ihres gesetzlichen Vertreters nutzen. **Die Nutzung ist untersagt, wenn Sie das 16. Lebensjahr noch nicht vollendet haben.**
+* Es ist untersagt, personenbezogenen Daten über sich oder andere Personen (z. B. Namen, Adressen, E-Mail-Adressen, Telefonnummern, ecUM-Nummern, Matrikelnummern, Informationen, die – ggf. auch in Kombination mit anderweitig leicht zugänglichen Informationen – personenbeziehbar sind) in den Chat oder das Feedback-Feld einzugeben. Dienstliche Kontaktdaten von Mitarbeitenden der UB Mannheim werden ausschließlich zu Informationszwecken angezeigt.
+* Es ist untersagt, sensible oder vertrauliche Daten der Universität Mannheim in den Chat einzugeben. Zulässig ist ausschließlich die Eingabe von Informationen, die als TLP:clear (für die allgemeine Öffentlichkeit bestimmt) eingestuft sind.
+* Es ist untersagt, Inhalte in den Chat einzugeben, die gegen geltendes Recht, Urheber  oder Persönlichkeitsrechte verstoßen, Hassrede, Diffamierung oder Spam darstellen.
+* Automatisierte Abfragen (Bots, Skripte) sind untersagt.
+* Chatverläufe können in vollständig anonymisierter Form zur Verbesserung des Angebots gespeichert werden.
+* Der Chatbot verwendet die OpenAI API und kann Daten auf Server außerhalb der EU übertragen. Dabei gelten zusätzlich die [Nutzungsbedingungen von OpenAI](https://openai.com/policies/terms-of-use/), soweit zutreffend.
+* Wir behalten uns vor, diesen Dienst jederzeit zu ändern oder einzustellen. Es besteht kein Rechtsanspruch auf die Zurverfügungstellung und Nutzung so-wie auf eine ununterbrochene Verfügbarkeit des KI-Chatbots.
+* Änderungen dieser Nutzungsbedingungen werden auf dieser Webseite veröffentlicht.
+* Die Universität Mannheim ist Anbieterin des KI-Chatbots. Der KI-Chatbot wird von der Universitätsbibliothek Mannheim betreut.
+
+Für Fragen zu diesem Dienst oder zur Meldung von Störungen wenden Sie sich bitte an:
+
+**Universität Mannheim – Universitätsbibliothek (UB)**
+E-Mail: [forschungsdaten@uni-mannheim.de](mailto:forschungsdaten@uni-mannheim.de)
+
+Weitere Angaben finden Sie im [Impressum](https://www.bib.uni-mannheim.de/impressum).
+
+**Haftungsausschluss und Haftungsprivilegien**
+
+* Die Universität Mannheim übernimmt keine Verantwortung für Handlungen von Nutzer\*innen, die auf Grundlage der vom Chatbot bereitgestellten Informationen vorgenommen werden. Für Entscheidungen, insbesondere im Hinblick auf die Inanspruchnahme von Leistungen der Universitätsbibliothek, sind allein die Nutzer\*innen verantwortlich; auch dann, wenn der Chatbot entsprechende Hinweise oder Empfehlungen ausspricht.
+* Die Universität Mannheim haftet nicht für Inhalte bzw. Eingaben in den KI-Chatbot, die durch Nutzer\*innen übermittelt und verarbeitet werden. Die Verantwortung hierfür liegt alleine bei den Nutzer\*innen. Sollten rechtswidrige Inhalte der Universität Mannheim bekannt werden, werden diese unverzüglich entfernt bzw. gesperrt. 
+* Die Universität Mannheim haftet nur für Vorsatz und grobe Fahrlässigkeit, außer es liegt eine Verletzung von Leben, Körper, Gesundheit oder wesentlicher Vertragspflichten vor, auf deren Einhaltung der Vertragspartner regelmäßig vertrauen durfte (Kardinalpflichten). Bei einer Verletzung der Kardinalpflichten ist die Haftung jedoch der Höhe nach auf vorhersehbare und vertragstypische Schäden beschränkt. Die Haftung im Falle der Übernahme einer Garantie oder aufgrund zwingender gesetzlicher Haftungstatbestände bleibt unberührt.

--- a/data/custom_docs/ubi-chatbot-nutzungsbedingungen.md
+++ b/data/custom_docs/ubi-chatbot-nutzungsbedingungen.md
@@ -3,7 +3,7 @@ title: Nutzungsbedingungen für den UBi (KI-Chatbot) der Universitätsbibliothek
 source_url_de: https://chat.bib.uni-mannheim.de/public/docs/ubi_policy.pdf
 source_url_en: https://chat.bib.uni-mannheim.de/public/docs/ubi_policy.pdf
 category: Services
-tags: ['Nutzungsbedingungen UBi', 'KI-Chatbot der Universitätsbibliothek Mannheim', 'UBi', 'Serviceangebot', 'Rechtliches']
+tags: ['Nutzungsbedingungen UBi', 'KI-Chatbot der Universitätsbibliothek Mannheim', 'UBi', 'Serviceangebot', 'Rechtliches', 'Chatbot der UB']
 language: de
 ---
 

--- a/docs/docs/data_collection_and_processing.md
+++ b/docs/docs/data_collection_and_processing.md
@@ -1,98 +1,153 @@
 # Data Collection and Processing Pipeline
 
-This README describes the **data collection** and **data processing** pipeline used to gather and structure content from the [University Library Mannheim](https://www.bib.uni-mannheim.de/) website.
+`Version 1.1`
+
+This document describes the **data collection** and **data processing** pipeline used to gather and structure content from the [University Library Mannheim](https://www.bib.uni-mannheim.de/) website.
+
+## Table of Contents
+
+1. [Overview](#overview)
+    - [Configuration](#configuration)
+    - [YAML Header for Custom Documents](#yaml-header-for-custom-documents)
+    - [Pipeline Steps](#pipeline-steps)
+    - [Full Pipeline Example](#full-pipeline-example)
+2. [Step 1: Data Collection — crawler.py](#step-1-data-collection--crawlerpy)
+    - [URL Discovery](#url-discovery)
+    - [Content Extraction](#content-extraction)
+    - [Output and Change Detection](#output-and-change-detection)
+    - [CLI Reference](#cli-reference)
+3. [Step 2: Data Processing — markdown_processing.py](#step-2-data-processing--markdown_processingpy)
+    - [LLM-Based Processing](#llm-based-processing)
+    - [Additional Post-Processing](#additional-post-processing)
+    - [Custom Documents Sync](#custom-documents-sync)
+    - [Hash Snapshot](#hash-snapshot)
+    - [CLI Reference](#cli-reference-1)
+4. [Data Flow](#data-flow)
 
 ## Overview
 
-The pipeline consists of two steps with **hash-based** file tracking to keep track of website updates. **Both** pipeline steps must be run to ensure the hash-based file tracking works correctly.
+The pipeline consists of two main steps with **hash-based file tracking** to detect website updates and changes to custom documents (i.e., internal documents not part of the library's website). **Both** steps must be run sequentially to ensure the hash-based tracking works correctly.
 
-### Prerequisites
+### Configuration
 
-Two variables in `code/config.py` are essential for data collection and processing:
+Four variables in `code/config.py` are essential for the pipeline:
 
 ```python
+URLS_TO_CRAWL = Path("../data/urls.txt")
 CRAWL_DIR = Path("../data/markdown")
+CUSTOM_DOCS_DIR = Path("../data/custom_docs")
 DATA_DIR = Path("../data/markdown_processed")
 ```
 
-- `CRAWL_DIR`: directory where the crawled website are saved as markdown files
-- `DATA_DIR`: directory where the post-processed markdown files are saved that are used as the knowledge base for the chatbot
+| Variable | Description |
+|---|---|
+| `URLS_TO_CRAWL` | Path to a text file containing URLs to crawl (one per line). If this file does not exist on disk, the crawler falls back to the XML sitemap. |
+| `CRAWL_DIR` | Directory where raw crawled markdown files are saved. |
+| `CUSTOM_DOCS_DIR` | Directory for custom markdown files not part of the library's website. Files must be `.md` format with a valid YAML header (see [below](#yaml-header-for-custom-documents)). |
+| `DATA_DIR` | Directory where final post-processed markdown files are saved — these files serve as the chatbot's knowledge base. |
 
-### Processing steps
+### YAML Header for Custom Documents
 
-1. **Data Collection** (`code/crawler.py`): Handles the web crawling and HTML extraction. Returns markdown files.
-2. **Data Processing** (`code/markdown_processing.py`): LLM-based post-processing of the crawled markdown files (content structuring, cleaning and YAML header injection). After the data processing is finished a **hash snapshot** is written to `CRAWL_DIR`.
+All markdown files in `CUSTOM_DOCS_DIR` **must** contain a valid YAML header. During LLM post-processing, YAML headers are automatically added to crawled pages. However, custom documents skip LLM processing to preserve their original content and structure, so the header must be added manually.
 
-Both python scripts come with `click` CLI interfaces to adjust different parameters (see below).
+It is **mandatory** to provide `source_url_de` and `source_url_en`, as the chatbot injects at least one URL in every response. Missing URLs may lead to hallucinated links.
 
-### Note
+#### Example YAML Header
 
-If `crawler.py` is run again, it checks if there are any changes to the already processed markdown files in `CRAWL_DIR` (meaning the website was changed) or if there are new URLs that weren't previously crawled. Only those website with updates / changes will then be available for data processing.
+```yaml
+---
+title: Nutzungsbedingungen für den UBi (KI-Chatbot) der Universitätsbibliothek Mannheim
+source_url_de: https://chat.bib.uni-mannheim.de/public/docs/ubi_policy.pdf
+source_url_en: https://chat.bib.uni-mannheim.de/public/docs/ubi_policy.pdf
+category: Services
+tags: ['Nutzungsbedingungen UBi', 'KI-Chatbot der Universitätsbibliothek Mannheim', 'UBi', 'Serviceangebot', 'Rechtliches']
+language: de
+---
+```
 
-### Full pipeline example
+### Pipeline Steps
 
-Make sure `venv` is active.
+1. **Data Collection** (`code/crawler.py`): Crawls the library website, extracts content from HTML pages, and saves the results as raw markdown files in `CRAWL_DIR`.
+2. **Data Processing** (`code/markdown_processing.py`): Performs LLM-based post-processing (content structuring, cleaning, YAML header injection) on new or changed files, runs additional domain-specific post-processing on `DATA_DIR`, syncs custom documents from `CUSTOM_DOCS_DIR` to `DATA_DIR`, and writes hash snapshots for change tracking.
+
+Both scripts provide `click` CLI interfaces with configurable options (see the respective [crawler CLI](#cli-reference) and [processing CLI](#cli-reference-1) sections).
+
+#### Important Note
+
+When `crawler.py` runs again after an initial crawl, it compares the newly crawled content against existing files in `CRAWL_DIR`. Only pages with actual content changes or previously uncrawled URLs produce updated files. Subsequently, `markdown_processing.py` uses hash-based comparison to identify which files in `CRAWL_DIR` have changed since the last processing run, and only processes those.
+
+### Full Pipeline Example
+
+Make sure the virtual environment is active.
 
 ```bash
 cd code
 
-# Crawl all URLs in ../data/urls.txt
+# Step 1: Crawl all URLs
 python crawler.py
 
-# Post-process all crawled URLs
+# Step 2: Post-process crawled files and sync custom docs
 python markdown_processing.py
 ```
 
-## Step 1: Data Collection → `crawler.py`
+## Step 1: Data Collection — `crawler.py`
 
-If `crawler.py` is run a backup of the current `CRAWL_DIR` will be created in `../data/backups`.
+When `crawler.py` runs, it first creates a timestamped backup of `CRAWL_DIR` in `../data/backups/`.
 
 ### URL Discovery
 
-- **Crawled URLs**: The website's [XML sitemap](`https://www.bib.uni-mannheim.de/xml-sitemap/`) is used for crawling if no `URLS_TO_CRAWL` path is defined in `code/config.py`
-- **Method**: Asynchronous HTTP requests using `aiohttp`
-- **Filtering**: Excludes URLs containing specific patterns (social media, portals, events, etc.)
+- **Primary source**: A text file at `URLS_TO_CRAWL` (default: `../data/urls.txt`) containing one URL per line.
+- **Fallback**: If the file does not exist on disk, the [XML sitemap](https://www.bib.uni-mannheim.de/xml-sitemap/) is fetched asynchronously via `aiohttp` and the discovered URLs are saved to `URLS_TO_CRAWL` for future runs.
+- **Filtering**: URLs matching specific patterns are excluded (social media, portals, events, blog posts, etc.).
 
 ### Content Extraction
 
-The crawler extracts content from specific HTML elements and CSS classes and avoids other parts of the website (e.g. footer and header sections):
+The crawler extracts content from the `<div id="page-content">` section of each page, targeting specific HTML elements and CSS classes while ignoring headers, footers, and navigation.
 
 #### Targeted HTML Elements
 
-- Headings: `h1`, `h2`, `h3`, `h4`, `h5`, `h6`
-- Text content: `p`, `b`, `strong`
-- Lists: `ul`, `li`
-- Tables: `tbody`, `table`
-- Links: `a`
+| Category | Elements |
+|---|---|
+| Headings | `h1`, `h2`, `h3`, `h4`, `h5`, `h6` |
+| Text | `p`, `b`, `strong` |
+| Lists | `ul`, `ol` |
+| Tables | `tbody`, `table` |
+| Links | `a` |
 
 #### Targeted CSS Classes
 
-- Address information: `uma-address-position`, `uma-address-details`, `uma-address-contact`
-- Navigation: `button`, `icon`, `teaser-link`
-- Content: `accordion-content`, `contenttable`
+| Category | Classes |
+|---|---|
+| Address blocks | `uma-address-position`, `uma-address-details`, `uma-address-contact` |
+| Navigation / UI | `button`, `icon`, `teaser-link` |
+| Content | `accordion-content`, `contenttable` |
 
 #### Exclusion Rules
 
-- Tags: `div` (when in excluded contexts)
-- Classes: `news`, `hide-for-large`, `gallery-slider-item`, `gallery-full-screen-slider-text-item`
+| Type | Values |
+|---|---|
+| Tags | `div` (when parent has an excluded class) |
+| Classes | `news`, `hide-for-large`, `gallery-slider-item`, `gallery-full-screen-slider-text-item` |
 
-### Content Processing Features
+#### Content Processing Features
 
-- **Link Resolution**: Converts relative URLs to absolute URLs
-- **Email Parsing**: Handles obfuscated email addresses (`mail-` → `@`)
-- **Address Formatting**: Structured parsing of contact information
-- **Table Conversion**: Converts HTML tables to Markdown format
-- **Profile Integration**: Fetches additional content from linked profile pages
+- **Link resolution**: Relative URLs are converted to absolute URLs.
+- **English URL extraction**: The English page URL is parsed from `<div class="language-selector">` and stored as `<en_url>` metadata for the LLM post-processing step.
+- **Email parsing**: Obfuscated email addresses (`mail-` → `@`) are decoded.
+- **Address formatting**: Structured parsing of `uma-address-*` contact blocks (name, position, street, phone, email, ORCID).
+- **Table conversion**: HTML tables are converted to markdown table format.
+- **Profile integration**: For elements with class `button`, linked profile pages are fetched and "Aufgaben" (tasks) sections are extracted and appended.
+- **Soft hyphen removal**: Invisible characters (soft hyphens, zero-width spaces, non-breaking spaces, etc.) are cleaned from crawled text.
 
-### Output
+### Output and Change Detection
 
-- Raw markdown files are saved to `../data/markdown/`
-- Filename generation based on URL path structure
-- Change detection using hash-based comparison
+- Raw markdown files are saved to `CRAWL_DIR` (default: `../data/markdown/`).
+- Filenames are generated from the URL path structure (e.g., `https://www.bib.uni-mannheim.de/foo/bar/` → `foo_bar.md`).
+- **Content comparison**: Before writing a file, the crawler compares the newly crawled content against the existing file on disk. Only files with actual changes are overwritten.
+- **404 handling**: If a previously crawled URL returns HTTP 404, the corresponding local markdown files in both `CRAWL_DIR` and `DATA_DIR` are deleted automatically.
+- After crawling completes, hash-based comparison against the stored snapshot identifies and reports all changed files.
 
-### Usage
-
-#### Command Line Interface
+### CLI Reference
 
 ```bash
 Usage: crawler.py [OPTIONS]
@@ -100,57 +155,81 @@ Usage: crawler.py [OPTIONS]
   Main crawling function.
 
 Options:
-  -w, --write-hashes-only / --no-write-hashes-only
-                                  Only write file hashes for CRAWL_DIR and
-                                  exit.
-  --help                          Show this message and exit.
+  -q, --quiet           Only print errors to stdout. Suppresses progress bars
+                        and info messages.
+  -w, --write-snapshot  Only write file hashes for CRAWL_DIR and exit.
+  --help                Show this message and exit.
 ```
 
-- `-w, --write-hashes-only`: Manually write a hash snapshot to `CRAWL_DIR` for the current files in `CRAWL_DIR`
+- `-w, --write-snapshot`: Manually writes a hash snapshot to `CRAWL_DIR/snapshot/md_hashes.json` for the current files without crawling.
 
-## Step 2: Data Processing → `markdown_processing.py`
+## Step 2: Data Processing — `markdown_processing.py`
 
-After step 1 was completed successfully `code/markdown_processing.py` will handle the post-processing of the crawled website using OpenAI's API.
+After Step 1, `markdown_processing.py` handles post-processing of the crawled markdown files using OpenAI's API. It also syncs custom documents from `CUSTOM_DOCS_DIR` to `DATA_DIR`.
+
+Before LLM processing begins, a timestamped backup of `DATA_DIR` is created in `../data/backups/`.
 
 ### LLM-Based Processing
 
-- **Model**: OpenAI GPT models (default: `gpt-4.1-mini-2025-04-14`)
-- **Processing**: Concurrent async processing with rate limiting
-- **Input**: Raw markdown from step 1
-- **Output**: Structured markdown with YAML headers
+| Setting | Value |
+|---|---|
+| **Model** | OpenAI GPT (default: `gpt-4.1-2025-04-14`) |
+| **Temperature** | `0` (deterministic output) |
+| **Concurrency** | Async processing with semaphore (max 3 concurrent requests) |
+| **Rate limiting** | Configurable delay between API requests |
+| **Fallback** | Sequential processing if async batch processing fails |
 
-### Processing Features
+**What the LLM does for each file:**
 
-- **YAML Header Addition**: Adds metadata headers to markdown files
-- **Content Structuring**: LLM-based content organization and formatting
-- **Heading Hierarchy**: Automatic adjustment of heading levels
+- Adds a structured YAML header with metadata (title, URLs, category, tags, language).
+- Eliminates redundant content while preserving all unique information.
+- Structures and cleans the markdown for optimal semantic search.
+- Fixes link formatting and heading hierarchy.
+- Validates and formats the output markdown using `mdformat`.
 
-### Post-Processing Operations
+**File selection** (default behavior, no CLI flags): Only files in `CRAWL_DIR` that are new or modified since the last hash snapshot are processed. Alternatively, specific files or an entire input directory can be passed via the `-f` or `-i` CLI options.
 
-#### 1. "Standorte" Processing
+### Additional Post-Processing
 
-- Groups location markdowns (Standorte) by base name
-- Appends contact information from linked pages
-- Merges related content and removes duplicate files
+After LLM processing, domain-specific post-processing merges and augments certain pages in `DATA_DIR`:
 
-#### 2. "Direktion"  Enhancement
+#### 1. "Standorte" (Locations)
 
-- Augments leadership page content
-- Updates titles and descriptions for consistency
+- Groups location files (`standorte*.md`) by base name.
+- Finds linked "Ansprechpersonen" (contact) pages.
+- Appends contact information to the shortest file in each group.
+- Removes the merged contact files after successful integration.
 
-#### 3. "Semesterapparat" Integration
+#### 2. "Direktion" (Management)
 
-- Merges application forms with main semesterapparat pages
-- Maintains proper section ordering
+- Augments the leadership page (`*direktion.md`).
+- Updates title and profile descriptions for consistency.
 
-#### 4. "Shibboleth" Content Integration
+#### 3. "Semesterapparat" (Course Reserves)
 
-- Appends Shibboleth access information to e-resources pages
-- Preserves contact sections at the end
+- Merges the application form page (`*semesterapparat_antrag*.md`) into the main semesterapparat page.
+- Inserts the merged content before the "Kontakt" section if present, otherwise appends it.
+- Removes the application file after merging.
 
-### Usage
+#### 4. "Shibboleth" (Authentication)
 
-#### Command Line Interface
+- Appends Shibboleth access information to the e-resources page (`*e-books-e-journals-und-datenbanken.md`).
+- Preserves the "Kontakt" section at the end.
+- Removes the Shibboleth file after merging.
+
+### Custom Documents Sync
+
+After all post-processing is complete, custom documents from `CUSTOM_DOCS_DIR` are synced to `DATA_DIR`:
+
+- Only **new or modified** files (detected via hash comparison against `CUSTOM_DOCS_DIR/snapshot/md_hashes.json`) are copied.
+- Custom documents are **not** processed by the LLM — they are copied as-is to preserve their manually curated content.
+- After syncing, a hash snapshot is written to `CUSTOM_DOCS_DIR/snapshot/md_hashes.json`.
+
+### Hash Snapshot
+
+At the end of processing (enabled by default, controlled by `--write-snapshot`), a hash snapshot is written to `CRAWL_DIR/snapshot/md_hashes.json`. This JSON file stores SHA256 hashes of all `.md` files and is used in future runs to identify which files have changed.
+
+### CLI Reference
 
 ```bash
 Usage: markdown_processing.py [OPTIONS]
@@ -159,27 +238,96 @@ Usage: markdown_processing.py [OPTIONS]
 
 Options:
   -i, --input-dir TEXT            Input directory containing markdown files to
-                                  process (default: CRAWL_DIR).
+                                  process (Default: CRAWL_DIR).
   -f, --files TEXT                Specific markdown files to process. Can be
                                   used multiple times. (e.g., -f file1.md -f
                                   file2.md)
-  -m, --model-name TEXT           Model name for LLM postprocessing. (default:
-                                  gpt-4o-mini-2024-07-18)
+  -m, --model-name TEXT           Model name for LLM postprocessing. (Default:
+                                  gpt-4.1-2025-04-14)
+  -t, --temperature INTEGER       LLM temperature for post-processing.
+                                  (Default: 0)
   -llm, --llm-processing / --no-llm-processing
                                   Run LLM post-processing on markdown files.
-                                  (default: True)
+                                  (Default: True)
   -add, --additional-processing / --no-additional-processing
                                   Run additional post-processing on markdown
-                                  files. (default: True)
-  -v, --verbose / --no-verbose    Enable verbose output during post-
-                                  processing. (default: False)
+                                  files. (Default: True)
+  -format, --format-markdown / --no-format-markdown
+                                  Run only markdown formatting for all files
+                                  in input_dir. (Default: False)
+  -w, --write-snapshot / --no-write-snapshot
+                                  Write a hash snapshot to input_dir.
+                                  (Default: True)
+  -q, --quiet                     Only print errors to stdout. Suppresses
+                                  progress bars and info messages. (Default:
+                                  True)
   --help                          Show this message and exit.
 ```
 
 ## Data Flow
 
-```
-XML Sitemap → URL Filtering → HTML Crawling → Content Extraction → Raw Markdown
-                                                                    ↓
-Final Markdown ← Post-Processing ← LLM Processing ← YAML Headers ← Structured Content
+```text
+                          ┌──────────────────────────┐
+                          │      URL Source          │
+                          │  urls.txt or XML Sitemap │
+                          └───────────┬──────────────┘
+                                      │
+                    ══════════════════════════════════════
+                    ║          Step 1: crawler.py         ║
+                    ══════════════════════════════════════
+                                      │
+                        Backup CRAWL_DIR → ../data/backups/
+                                      │
+                        Crawl HTML pages & extract content
+                                      │
+                        Content-based change detection
+                        (only write new/changed files)
+                                      │
+                                      ▼
+          ┌───────────────────────────────────────────────────┐
+          │                      CRAWL_DIR                    │
+          │                 ../data/markdown/                 │
+          │   (raw markdown files + snapshot/md_hashes.json)  │
+          └───────────────────────┬───────────────────────────┘
+                                  │
+                    ══════════════════════════════════════
+                    ║    Step 2: markdown_processing.py   ║
+                    ══════════════════════════════════════
+                                  │
+                    Hash-based change detection against
+                    CRAWL_DIR/snapshot/md_hashes.json
+                    (only process new/changed files)
+                                  │
+                    Backup DATA_DIR → ../data/backups/
+                                  │
+                    LLM post-processing
+                    (YAML header, content cleanup,
+                     deduplication, mdformat)
+                                  │
+                    Write results to DATA_DIR
+                                  │
+                    Additional post-processing on DATA_DIR
+                    ├── Standorte: merge contact pages
+                    ├── Direktion: augment leadership page
+                    ├── Semesterapparat: merge application form
+                    └── Shibboleth: merge auth info
+                                  │
+                                  │     ┌──────────────────────────────┐
+                                  │     │      CUSTOM_DOCS_DIR         │
+                                  │     │   ../data/custom_docs/       │
+                                  │     │  (manually curated .md files │
+                                  │     │ + snapshot/md_hashes.json)   │
+                                  │     └──────────────┬───────────────┘
+                                  │                    │
+                                  │     Hash-based change detection
+                                  │     Copy new/changed files (no LLM)
+                                  │                    │
+                                  ▼                    ▼
+          ┌───────────────────────────────────────────────────┐
+          │                    DATA_DIR                       │
+          │           ../data/markdown_processed/             │
+          │                                                   │
+          │   Final knowledge base for the chatbot            │
+          │   (LLM-processed crawled files + custom docs)     │
+          └───────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
- Added a custom_docs folder to `/data` to include non-website markdown files
    - markdown files placed in custom_docs will NOT be processed by LLM to keep the original content and structure; therefore a YAML header has to be added manually. See the updated documentation (`docs/docs/data_collection_and_processing.md`) or check the provided custom doc `data/custom_docs/ubi-chatbot-nutzungsbedingungen.md`
    - added a new `CUSTOM_DOCS_DIR` parameter in `config.py`
- Improve `crawler.py`: Deleted urls in `urls.txt` now correctly remove their markdown counterparts from `CRAWL_DIR` and `DATA_DIR`
- Improved the LLM post-processing logic in `markdown_processing.py`
- Updated the documentation for data collection and LLM processing in `docs/docs/data_collection_and_processing.md`
- Updated prompts in `prompts.py`:
    - Added GIP and UBi to abreviations
    - Changed some system prompts so that the chatbot is aware that "UBi" refers to itself