### PR TITLE
Add environment variable DISABLED_AREAS to remove areas from occupancy plot

### DIFF
--- a/code/app.py
+++ b/code/app.py
@@ -368,6 +368,13 @@ async def handle_sitzplatz_route(
         data = get_occupancy_data()
         areas = data["areas"]
 
+        # Remove selected areas from plotting (i.e. if closed)
+        # Set environment variable DISABLED_AREAS to a comma-separated list of
+        # area identifiers
+        disabled_areas = os.getenv('DISABLED_AREAS', '').split(',')
+        for area in disabled_areas:
+            areas.pop(area, '')
+
         # Plot title and labels
         heading = translate("seats_last_updated", detected_language)
         response = f"{heading}: {data['lastupdated']}"

--- a/compose.yml
+++ b/compose.yml
@@ -17,4 +17,5 @@ services:
       - CHAT_MODEL=${CHAT_MODEL}
       - DELETE_BACKUPS_AFTER=${DELETE_BACKUPS_AFTER}
       - QUIET_MODE=${QUIET_MODE}
+      - DISABLED_AREAS=${DISABLED_AREAS}
     restart: unless-stopped

--- a/env.template
+++ b/env.template
@@ -17,3 +17,7 @@ OLLAMA_EMBEDDING_MODEL=mxbai-embed-large
 DELETE_BACKUPS_AFTER=7
 # Enable to suppress all non-error messages and progress bars in CLI
 QUIET_MODE=False
+
+# Additional settings
+# Remove select library areas from occupancy plot
+DISABLED_AREAS=a3,a5


### PR DESCRIPTION
This feature is required to make the plotting of occupancy data for a given library area optional, i.e. if the library area is temporary closed.